### PR TITLE
[Common] 현재 사용자 정보를 자동으로 주입하는 커스텀 리졸버 구현

### DIFF
--- a/src/main/java/com/poko/apps/common/domain/vo/CurrentUserInfo.java
+++ b/src/main/java/com/poko/apps/common/domain/vo/CurrentUserInfo.java
@@ -1,0 +1,14 @@
+package com.poko.apps.common.domain.vo;
+
+import com.poko.apps.common.domain.enums.UserRoleType;
+
+public record CurrentUserInfo(
+    Long userId,
+    UserRoleType userRoleType
+) {
+
+  public static CurrentUserInfo of(Long userId, UserRoleType userRoleType) {
+    return new CurrentUserInfo(userId, userRoleType);
+  }
+
+}

--- a/src/main/java/com/poko/apps/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/poko/apps/common/exception/CommonErrorCode.java
@@ -15,8 +15,8 @@ public enum CommonErrorCode implements ErrorCode {
   INTERNAL_ERROR(-1, "내부 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   BAD_REQUEST_CONTEXT_HOLDER(-1, "요청으로부터 RequestContextHolder 를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
   NOT_FOUND_USER_ROLE_BY_HEADER(-1, "헤더에서 X-User-Role 이 비어있거나 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  INVALID_ROLE_VALUE(-1, "유효하지 않은 회원 권한 입니다.", HttpStatus.BAD_REQUEST);
-
+  INVALID_ROLE_VALUE(-1, "유효하지 않은 회원 권한 입니다.", HttpStatus.BAD_REQUEST),
+  INVALID_USER_ID_VALUE(-1, "유효하지 않은 회원 ID 입니다.", HttpStatus.BAD_REQUEST);
 
 
   private final Integer code;

--- a/src/main/java/com/poko/apps/common/infrastructure/config/WebConfig.java
+++ b/src/main/java/com/poko/apps/common/infrastructure/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.poko.apps.common.infrastructure.config;
+
+import com.poko.apps.common.resolver.CurrentUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(currentUserArgumentResolver);
+  }
+}

--- a/src/main/java/com/poko/apps/common/resolver/CurrentUser.java
+++ b/src/main/java/com/poko/apps/common/resolver/CurrentUser.java
@@ -1,0 +1,10 @@
+package com.poko.apps.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser { }

--- a/src/main/java/com/poko/apps/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/poko/apps/common/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,49 @@
+package com.poko.apps.common.resolver;
+
+import static com.poko.apps.common.exception.CommonErrorCode.INVALID_INPUT;
+import static com.poko.apps.common.exception.CommonErrorCode.UNAUTHORIZED;
+
+import com.poko.apps.common.domain.enums.UserRoleType;
+import com.poko.apps.common.domain.vo.CurrentUserInfo;
+import com.poko.apps.common.exception.CustomException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private static final String USER_ID_HEADER = "X-User-Id";
+  private static final String USER_ROLE_HEADER = "X-User_Role";
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(CurrentUser.class)
+        && parameter.getParameterType().equals(CurrentUserInfo.class);
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+    String userId = webRequest.getHeader(USER_ID_HEADER);
+    String userRole = webRequest.getHeader(USER_ROLE_HEADER);
+
+    if (userId == null || userRole == null) {
+      throw new CustomException(UNAUTHORIZED);
+    }
+
+    try {
+      long id = Long.parseLong(userId);
+      UserRoleType role = UserRoleType.valueOf(userRole);
+      return CurrentUserInfo.of(id, role);
+    } catch (NumberFormatException e) {
+      throw new CustomException(INVALID_INPUT);
+    } catch (IllegalArgumentException e) {
+      throw new CustomException(UNAUTHORIZED);
+    }
+  }
+}

--- a/src/main/java/com/poko/apps/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/poko/apps/common/resolver/CurrentUserArgumentResolver.java
@@ -1,11 +1,13 @@
 package com.poko.apps.common.resolver;
 
-import static com.poko.apps.common.exception.CommonErrorCode.INVALID_INPUT;
+import static com.poko.apps.common.exception.CommonErrorCode.INVALID_ROLE_VALUE;
+import static com.poko.apps.common.exception.CommonErrorCode.INVALID_USER_ID_VALUE;
 import static com.poko.apps.common.exception.CommonErrorCode.UNAUTHORIZED;
 
 import com.poko.apps.common.domain.enums.UserRoleType;
 import com.poko.apps.common.domain.vo.CurrentUserInfo;
 import com.poko.apps.common.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -13,6 +15,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Slf4j
 @Component
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -38,12 +41,20 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
     try {
       long id = Long.parseLong(userId);
+
+      if (id <= 0) {
+        log.warn("유효하지 않은 userId 값: {}", userId);
+        throw new CustomException(INVALID_USER_ID_VALUE);
+      }
+
       UserRoleType role = UserRoleType.valueOf(userRole);
       return CurrentUserInfo.of(id, role);
     } catch (NumberFormatException e) {
-      throw new CustomException(INVALID_INPUT);
+      log.warn("유효하지 않은 userId 형식: {}", e.toString());
+      throw new CustomException(INVALID_USER_ID_VALUE);
     } catch (IllegalArgumentException e) {
-      throw new CustomException(UNAUTHORIZED);
+      log.warn("유효하지 않은 userRole 값: {}", userRole);
+      throw new CustomException(INVALID_ROLE_VALUE);
     }
   }
 }


### PR DESCRIPTION
## ✨ 작업 개요

- Spring MVC에서 컨트롤러 메서드의 매개변수에 현재 사용자 정보를 자동으로 주입하기 위해 커스텀 Argument Resolver 구현
- `@Currentuser` 애너테이션이 붙은 파라미터에 CurrentUserInfo 객체를 주입
- Spring MVC에 등록하기 위해 WebMvcConfigurer 구현체 작성하고 addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers)  오버라이딩으로 직접 구현한 Argument Resolver를 추가


## ✅ 체크리스트
- [x] 기능 구현 완료
- [x] 로컬 테스트 완료
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 코드 리뷰 기준 충족

## 🔗 관련 이슈
Closes #이슈번호

## 💬 기타 참고 사항
공유할 내용이나 특이사항이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 컨트롤러 메서드에서 사용자 정보를 자동으로 주입받을 수 있는 기능이 추가되었습니다. 이제 `@CurrentUser` 어노테이션을 사용하면 요청 헤더의 사용자 정보(`X-User-Id`, `X-User-Role`)를 손쉽게 활용할 수 있습니다.
    - 사용자 인증 및 권한 확인 과정에서 잘못된 정보가 전달될 경우 적절한 예외 처리가 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->