### PR TITLE
[User] 회원 동적 검색 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id "org.sonarqube" version "6.0.1.5171"
+	id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 group = 'com'
@@ -24,6 +25,10 @@ repositories {
 	mavenCentral()
 }
 
+
+ext {
+	set('querydslVersion', "5.1.0")
+}
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -55,6 +60,12 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/poko/apps/user/application/dto/auth/request/UserSearchCondition.java
+++ b/src/main/java/com/poko/apps/user/application/dto/auth/request/UserSearchCondition.java
@@ -1,0 +1,22 @@
+package com.poko.apps.user.application.dto.auth.request;
+
+import com.poko.apps.user.domain.enums.user.UserRoleType;
+import java.time.LocalDateTime;
+
+public record UserSearchCondition(
+    Long id,
+    String email,
+    String name,
+    String phone,
+    UserRoleType userRoleType,
+    Long createdBy,
+    LocalDateTime createdFrom,
+    LocalDateTime createdTo,
+    Long modifiedBy,
+    LocalDateTime modifiedFrom,
+    LocalDateTime modifiedTo,
+    Long deletedBy,
+    LocalDateTime deletedFrom,
+    LocalDateTime deletedTo
+) {
+}

--- a/src/main/java/com/poko/apps/user/application/dto/auth/response/GetUsersResponse.java
+++ b/src/main/java/com/poko/apps/user/application/dto/auth/response/GetUsersResponse.java
@@ -1,0 +1,20 @@
+package com.poko.apps.user.application.dto.auth.response;
+
+import com.poko.apps.user.domain.enums.user.UserRoleType;
+import java.time.LocalDateTime;
+
+public record GetUsersResponse(
+    Long id,
+    String email,
+    String name,
+    String phone,
+    String profileImage,
+    UserRoleType userRoleType,
+    Long createdBy,
+    LocalDateTime createdAt,
+    Long modifiedBy,
+    LocalDateTime modifiedAt,
+    Long deletedBy,
+    LocalDateTime deletedAt
+) {
+}

--- a/src/main/java/com/poko/apps/user/application/service/user/UserService.java
+++ b/src/main/java/com/poko/apps/user/application/service/user/UserService.java
@@ -1,9 +1,15 @@
 package com.poko.apps.user.application.service.user;
 
 import com.poko.apps.common.domain.vo.CurrentUserInfo;
+import com.poko.apps.user.application.dto.auth.request.UserSearchCondition;
 import com.poko.apps.user.application.dto.auth.response.GetUserResponse;
+import com.poko.apps.user.application.dto.auth.response.GetUsersResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface UserService {
 
   GetUserResponse getMyProfile(CurrentUserInfo info);
+
+  Page<GetUsersResponse> getUsers(UserSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/poko/apps/user/application/service/user/UserServiceImpl.java
+++ b/src/main/java/com/poko/apps/user/application/service/user/UserServiceImpl.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -48,6 +49,7 @@ public class UserServiceImpl implements UserService {
     return GetUserResponse.from(userById);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public Page<GetUsersResponse> getUsers(UserSearchCondition condition, Pageable pageable) {
 

--- a/src/main/java/com/poko/apps/user/application/service/user/UserServiceImpl.java
+++ b/src/main/java/com/poko/apps/user/application/service/user/UserServiceImpl.java
@@ -8,10 +8,15 @@ import static com.poko.apps.user.domain.enums.user.UserErrorCode.USER_NOT_FOUND_
 
 import com.poko.apps.common.domain.vo.CurrentUserInfo;
 import com.poko.apps.common.exception.CustomException;
+import com.poko.apps.user.application.dto.auth.request.UserSearchCondition;
 import com.poko.apps.user.application.dto.auth.response.GetUserResponse;
+import com.poko.apps.user.application.dto.auth.response.GetUsersResponse;
 import com.poko.apps.user.domain.entity.User;
+import com.poko.apps.user.domain.repository.user.UserQueryRepository;
 import com.poko.apps.user.domain.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -19,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
+  private final UserQueryRepository userQueryRepository;
 
   private User findUserById(Long userId) {
     return userRepository.findById(userId)
@@ -42,6 +48,11 @@ public class UserServiceImpl implements UserService {
     return GetUserResponse.from(userById);
   }
 
-  
+  @Override
+  public Page<GetUsersResponse> getUsers(UserSearchCondition condition, Pageable pageable) {
+
+    return userQueryRepository.getUsersByCondition(condition, pageable);
+  }
+
 
 }

--- a/src/main/java/com/poko/apps/user/domain/repository/user/UserQueryRepository.java
+++ b/src/main/java/com/poko/apps/user/domain/repository/user/UserQueryRepository.java
@@ -1,0 +1,12 @@
+package com.poko.apps.user.domain.repository.user;
+
+import com.poko.apps.user.application.dto.auth.request.UserSearchCondition;
+import com.poko.apps.user.application.dto.auth.response.GetUsersResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserQueryRepository {
+
+  Page<GetUsersResponse> getUsersByCondition(UserSearchCondition condition, Pageable pageable);
+
+}

--- a/src/main/java/com/poko/apps/user/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/com/poko/apps/user/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,16 @@
+package com.poko.apps.user.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @Bean
+  JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}

--- a/src/main/java/com/poko/apps/user/infrastructure/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/com/poko/apps/user/infrastructure/persistence/jpa/UserJpaRepository.java
@@ -6,9 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<User, Long>, UserRepository {
 
-
-
-
-
-
 }

--- a/src/main/java/com/poko/apps/user/infrastructure/persistence/querydsl/UserPredicate.java
+++ b/src/main/java/com/poko/apps/user/infrastructure/persistence/querydsl/UserPredicate.java
@@ -1,0 +1,50 @@
+package com.poko.apps.user.infrastructure.persistence.querydsl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.BooleanPath;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.core.types.dsl.StringPath;
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+public final class UserPredicate {
+
+  private UserPredicate() {
+    throw new UnsupportedOperationException("유틸리티 클래스로 인스턴스화할 수 없습니다.");
+  }
+
+  public static BooleanExpression like(StringPath path, String keyword) {
+    return (keyword == null || keyword.isBlank()) ? null : path.containsIgnoreCase(keyword.trim());
+  }
+
+  public static BooleanExpression eq(StringPath path, String keyword) {
+    return (keyword == null || keyword.isBlank()) ? null : path.equalsIgnoreCase(keyword.trim());
+  }
+
+  public static <T> BooleanExpression eq(SimpleExpression<T> path, T value) {
+    return value == null ? null : path.eq(value);
+  }
+
+  public static BooleanExpression eq(BooleanPath path, Boolean value) {
+    return value == null ? null : path.eq(value);
+  }
+
+  public static <T> BooleanExpression in(SimpleExpression<T> path, Collection<T> values) {
+    return (values == null || values.isEmpty()) ? null : path.in(values);
+  }
+
+  public static BooleanExpression between(DateTimePath<LocalDateTime> path, LocalDateTime from, LocalDateTime to) {
+    if (from != null && to != null) {
+      return path.between(from, to);
+    }
+    if (from != null) {
+      return path.goe(from);
+    }
+    if (to != null) {
+      return path.loe(to);
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/com/poko/apps/user/infrastructure/persistence/querydsl/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/poko/apps/user/infrastructure/persistence/querydsl/UserQueryRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.poko.apps.user.infrastructure.persistence.querydsl;
+
+import com.poko.apps.user.application.dto.auth.request.UserSearchCondition;
+import com.poko.apps.user.application.dto.auth.response.GetUsersResponse;
+import com.poko.apps.user.domain.entity.QUser;
+import com.poko.apps.user.domain.repository.user.UserQueryRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<GetUsersResponse> getUsersByCondition(UserSearchCondition condition, Pageable pageable) {
+    QUser user = QUser.user;
+
+    BooleanBuilder builder = new BooleanBuilder()
+        .and(UserPredicate.eq(user.id, condition.id()))
+        .and(UserPredicate.like(user.email, condition.email()))
+        .and(UserPredicate.like(user.name, condition.name()))
+        .and(UserPredicate.eq(user.userRoleType, condition.userRoleType()))
+        .and(UserPredicate.eq(user.phone, condition.phone()))
+        .and(UserPredicate.eq(user.createdBy, condition.createdBy()))
+        .and(UserPredicate.eq(user.modifiedBy, condition.modifiedBy()))
+        .and(UserPredicate.eq(user.deletedBy, condition.deletedBy()))
+        .and(UserPredicate.between(user.createdAt, condition.createdFrom(), condition.createdTo()))
+        .and(UserPredicate.between(user.modifiedAt, condition.modifiedFrom(), condition.modifiedTo()))
+        .and(UserPredicate.between(user.deletedAt, condition.deletedFrom(), condition.deletedTo()));
+
+    List<GetUsersResponse> contents = queryFactory
+        .select(Projections.constructor(
+            GetUsersResponse.class,
+            user.id,
+            user.email,
+            user.name,
+            user.phone,
+            user.profileImage,
+            user.userRoleType,
+            user.createdBy,
+            user.createdAt,
+            user.modifiedBy,
+            user.modifiedAt,
+            user.deletedBy,
+            user.deletedAt
+        ))
+        .from(user)
+        .where(builder)
+        .orderBy(UserSortUtil.toOrderSpecifiers(pageable.getSort()).toArray(new OrderSpecifier[0]))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long count = queryFactory
+        .select(user.count())
+        .from(user)
+        .where(builder)
+        .fetchOne();
+
+    return new PageImpl<>(contents, pageable, count != null ? count : 0);
+  }
+}

--- a/src/main/java/com/poko/apps/user/infrastructure/persistence/querydsl/UserSortUtil.java
+++ b/src/main/java/com/poko/apps/user/infrastructure/persistence/querydsl/UserSortUtil.java
@@ -1,0 +1,45 @@
+package com.poko.apps.user.infrastructure.persistence.querydsl;
+
+import com.poko.apps.user.domain.entity.User;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.springframework.data.domain.Sort;
+
+public class UserSortUtil {
+
+  private static final Set<String> ALLOWED_SORT_FIELDS = Set.of(
+      "id", "email", "name", "phone", "profileImage", "userRoleType",
+      "createdAt", "createdBy", "modifiedAt", "modifiedBy", "deletedAt", "deletedBy"
+  );
+
+  private UserSortUtil() {
+    throw new UnsupportedOperationException("유틸리티 클래스로 인스턴스화할 수 없습니다.");
+  }
+
+  public static List<OrderSpecifier<?>> toOrderSpecifiers(Sort sort) {
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+    PathBuilder<User> entityPath = new PathBuilder<>(User.class, "user");
+
+    for (Sort.Order order : sort) {
+      String property = order.getProperty().trim();
+      if (!ALLOWED_SORT_FIELDS.contains(property)) {
+        continue;
+      }
+
+      Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+
+      orderSpecifiers.add(new OrderSpecifier<>(
+          direction,
+          entityPath.getComparable(property, Comparable.class)
+      ));
+    }
+
+    return orderSpecifiers;
+  }
+
+
+}

--- a/src/main/java/com/poko/apps/user/presentation/UserController.java
+++ b/src/main/java/com/poko/apps/user/presentation/UserController.java
@@ -1,14 +1,24 @@
 package com.poko.apps.user.presentation;
 
+import static com.poko.apps.common.domain.enums.UserRoleType.ROLE_ADMIN;
+import static com.poko.apps.user.domain.enums.user.UserSuccessCode.USERS_GET_SUCCESS;
 import static com.poko.apps.user.domain.enums.user.UserSuccessCode.USER_GET_SUCCESS;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 import static org.springframework.http.HttpStatus.OK;
 
+import com.poko.apps.common.aop.CustomPreAuthorize;
 import com.poko.apps.common.domain.vo.CurrentUserInfo;
 import com.poko.apps.common.resolver.CurrentUser;
 import com.poko.apps.common.util.response.ApiResponse;
+import com.poko.apps.user.application.dto.auth.request.UserSearchCondition;
 import com.poko.apps.user.application.dto.auth.response.GetUserResponse;
+import com.poko.apps.user.application.dto.auth.response.GetUsersResponse;
 import com.poko.apps.user.application.service.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +31,6 @@ public class UserController {
 
   private final UserService userService;
 
-  // 자신의 회원 정보 조회
   @GetMapping("/profile")
   public ResponseEntity<ApiResponse<GetUserResponse>> getMyProfile(@CurrentUser CurrentUserInfo info) {
 
@@ -36,7 +45,24 @@ public class UserController {
         );
   }
 
-  // 동적 회원 조회
+  @CustomPreAuthorize(userRoleType = {ROLE_ADMIN})
+  @GetMapping
+  public ResponseEntity<ApiResponse<Page<GetUsersResponse>>> getUsers(
+      @ParameterObject UserSearchCondition condition,
+      @SortDefault.SortDefaults({
+          @SortDefault(sort = "createdAt", direction = DESC),
+      }) Pageable pageable
+  ) {
+    return ResponseEntity
+        .status(OK)
+        .body(
+            new ApiResponse<>(
+                USERS_GET_SUCCESS.getCode(),
+                USERS_GET_SUCCESS.getMessage(),
+                userService.getUsers(condition, pageable)
+            )
+        );
+  }
 
   // 회원 아이디 수정
 

--- a/src/test/java/com/poko/apps/user/http/auth-requests.http
+++ b/src/test/java/com/poko/apps/user/http/auth-requests.http
@@ -52,4 +52,17 @@ Authorization: Bearer {{accessToken}}
 GET http://localhost:10000/api/v1/users/profile
 Content-Type: application/json
 X-User-Id: {{userId}}
-X-User_Role: {{userRoleType}}
+X-User-Role: {{userRoleType}}
+
+
+### 동적 회원 조회
+GET http://localhost:10000/api/v1/users?id=100&email=test@example.com&name=홍길동&phone=01012345678&userRoleType=ROLE_ADMIN&isDeleted=false&createdBy=1&createdFrom=2024-01-01T00:00:00&createdTo=2025-01-01T00:00:00&modifiedBy=2&modifiedFrom=2024-06-01T00:00:00&modifiedTo=2025-01-01T00:00:00&deletedBy=3&deletedFrom=2024-12-01T00:00:00&deletedTo=2025-01-01T00:00:00&page=0&size=20&sort=createdAt,desc
+Content-Type: application/json
+X-User-Id: {{userId}}
+X-User-Role: {{userRoleType}}
+
+### 동적 회원 조회
+GET http://localhost:10000/api/v1/users?id=1
+Content-Type: application/json
+X-User-Id: {{userId}}
+X-User-Role: {{userRoleType}}


### PR DESCRIPTION
## ✨ 작업 개요
간결하게 작업의 핵심을 설명해주세요.

## ✅ 체크리스트
- [ ] 기능 구현 완료
- [ ] 로컬 테스트 완료
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 코드 리뷰 기준 충족

## 🔗 관련 이슈
Closes #이슈번호

## 💬 기타 참고 사항
공유할 내용이나 특이사항이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 관리자를 위한 동적 회원 검색 및 페이징 기능이 추가되었습니다. 다양한 조건(이메일, 이름, 역할, 생성/수정/삭제 정보 등)으로 회원 목록을 조회할 수 있습니다.
    - OpenAPI UI를 통한 API 문서 확인 기능이 도입되었습니다.

- **버그 수정**
    - 프로필 조회 API의 헤더 키 오타가 수정되었습니다.

- **문서화**
    - 회원 검색 관련 테스트용 HTTP 요청 예시가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->